### PR TITLE
Pass errors through callback

### DIFF
--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -265,6 +265,8 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
       //  Try/catch ensures that if the reciever throws
       //  it goes to the callback or the event emitter for
       //  HttpConnection not Http.ClientRequest
+      //  TODO filter out weird errors and throw programmer 
+      //  errors. Srsly you guys this TODO is important. TODO.
       try {
         self.transport.receiver(decodeCallback)(buf);
       } catch (err) {

--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -193,8 +193,8 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
         }
       }
     }
-    catch (e) {
-      if (e instanceof ttransport.InputBufferUnderrunError) {
+    catch (err) {
+      if (err instanceof ttransport.InputBufferUnderrunError) {
         // TODO Unclear if this is an error or an expected
         // case in TFramed. We should add logging if it is an error
         // Also unclear what the recovery is from rollback to 0
@@ -203,9 +203,9 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
         // do not throw in callbacks
         // this should return an error to the callback
         if (sCallback) {
-          sCallback(e);
+          sCallback(err);
         } else {
-          self.emit(e);
+          self.emit('error', err);
         }
         // or if it happens after it should be logged and
         // noop.

--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -152,7 +152,7 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
           delete self.seqId2Service[header.rseqid];
         }
         // This replaces the called back of the real seqid in the client's
-        // stack with a callback on its negative compliment
+        // stack with a callback on its negative complement
         // when called it commits the read head on the transport
         // removes the real seqid and calls the callback if any
         // relies on a slightly gross closure reference to 
@@ -163,7 +163,9 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
           var clientCallback = client._reqs[header.rseqid];
           delete client._reqs[header.rseqid];
           if (clientCallback) {
-            clientCallback(err, success);
+            process.nextTick(function() {
+              clientCallback(err, success);
+            });
           }
         };
         /*jshint +W083 */
@@ -186,9 +188,15 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
                          thrift.TApplicationExceptionType.WRONG_METHOD_NAME,
                          "Received a response to an unknown RPC function");
           if (sCallback) {
-            return sCallback(err);
+            //Isolate the callback from the try/catch here
+            process.nextTick(function() {
+              sCallback(err);
+            });
           } else {
-            self.emit("error", err);
+            //Isolate the error handling from the try/catch here
+            process.nextTick(function() {
+              self.emit("error", err);
+            });
           }
         }
       }
@@ -203,9 +211,15 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
         // do not throw in callbacks
         // this should return an error to the callback
         if (sCallback) {
-          sCallback(err);
+          //Isolate callback from try/catch here
+          process.nextTick(function() {
+            sCallback(err);
+          });
         } else {
-          self.emit('error', err);
+          //Isolate error handling from try/catch here
+          process.nextTick(function() {
+            self.emit('error', err);
+          });
         }
         // or if it happens after it should be logged and
         // noop.
@@ -260,22 +274,8 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
         data[i].copy(buf, pos); 
         pos += data[i].length; 
       }
-      // Get the receiver function for the transport and
-      //  call it with the buffer
-      //  Try/catch ensures that if the reciever throws
-      //  it goes to the callback or the event emitter for
-      //  HttpConnection not Http.ClientRequest
-      //  TODO filter out weird errors and throw programmer 
-      //  errors. Srsly you guys this TODO is important. TODO.
-      try {
-        self.transport.receiver(decodeCallback, seqid)(buf);
-      } catch (err) {
-        if (callback) {
-          callback(err);
-        } else {
-          self.emit('error', err);
-        }
-      }
+      // Reciever should not throw decodeCallback can deal with its own
+      self.transport.receiver(decodeCallback, seqid)(buf);
     });
   };
 };

--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -268,7 +268,7 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
       //  TODO filter out weird errors and throw programmer 
       //  errors. Srsly you guys this TODO is important. TODO.
       try {
-        self.transport.receiver(decodeCallback)(buf);
+        self.transport.receiver(decodeCallback, seqid)(buf);
       } catch (err) {
         if (callback) {
           callback(err);

--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -111,7 +111,12 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
   // gets singleton transport that has data in its buffers
   // flush causes this to decode as much is on the transport
   // as is possible
-  function decodeCallback(transport_with_data) {
+  function decodeCallback(transport_with_data, seqid) {
+    //callback based on passed seqid
+    var sCallback;
+    if (seqid) {
+      sCallback = self.client._reqs[seqid];
+    }
     // create (another) new protocol for the transport
     // not sure why this is needed since each call to the
     // service client also does `new this.pClass(this.output)`
@@ -176,10 +181,15 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
           // callback so we should be able to associate it anyway
           // until we have actual multiplexing
           // This might be something that could be caused by a server error --Tom
-          self.emit("error",
-                    new thrift.TApplicationException(
-                       thrift.TApplicationExceptionType.WRONG_METHOD_NAME,
-                       "Received a response to an unknown RPC function"));
+          // -- Trying with sCallback for now -- TODO verify
+          var err = new thrift.TApplicationException(
+                         thrift.TApplicationExceptionType.WRONG_METHOD_NAME,
+                         "Received a response to an unknown RPC function");
+          if (sCallback) {
+            return sCallback(err);
+          } else {
+            self.emit("error", err);
+          }
         }
       }
     }
@@ -190,12 +200,16 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
         // Also unclear what the recovery is from rollback to 0
         transport_with_data.rollbackPosition();
       } else {
-        // TODO do not throw in callbacks
+        // do not throw in callbacks
         // this should return an error to the callback
+        if (sCallback) {
+          sCallback(e);
+        } else {
+          self.emit(e);
+        }
         // or if it happens after it should be logged and
         // noop.
-        // TODO logging here
-        throw e;
+        // TODO investigate logging here
       }
     }
   }
@@ -207,17 +221,24 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
   // probably we do not care about that
   // but maybe we do
   // TODO replace with a stream safe buffering implementation
-  this.responseCallback = function(response) {
+  this.responseCallback = function(seqid, response) {
     var data = [];
     var dataLen = 0;
+    var callback;
 
-    // TODO callback the error instead of just vomitting
-    // all errors at the singleton client
-    // this will requiring have access to the callback 
-    // or at least its seqid
-    response.on('error', function (e) {
-      self.emit("error", e);
-    });
+    // callback the error instead of just vomitting
+    // all errors at the singleton client if possible
+    if (seqid) {
+      callback = self.client._reqs[seqid];
+    }
+
+    if (callback) {
+      response.on('error', callback);
+    } else {
+      response.on('error', function (e) {
+        self.emit("error", e);
+      });
+    }
 
     // When running directly under node, chunk will be a buffer,
     // however, when running in a Browser (e.g. Browserify), chunk
@@ -239,11 +260,20 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
         data[i].copy(buf, pos); 
         pos += data[i].length; 
       }
-      //Get the receiver function for the transport and
+      // Get the receiver function for the transport and
       //  call it with the buffer
-      //  TODO ensure that reciever can not throw
-      //  or if it does catch and callback those errors
-      self.transport.receiver(decodeCallback)(buf);
+      //  Try/catch ensures that if the reciever throws
+      //  it goes to the callback or the event emitter for
+      //  HttpConnection not Http.ClientRequest
+      try {
+        self.transport.receiver(decodeCallback)(buf);
+      } catch (err) {
+        if (callback) {
+          callback(err);
+        } else {
+          self.emit('error', err);
+        }
+      }
     });
   };
 };
@@ -256,8 +286,24 @@ util.inherits(HttpConnection, EventEmitter);
  * @event {error} the "error" event is raised upon request failure passing the 
  *     Node.js error object to the listener.  
  */
-HttpConnection.prototype.write = function(data) {
+HttpConnection.prototype.write = function(data, seqid) {
   var self = this;
+  var callback;
+  // if we have a seqid prefer to return to the callback than
+  // emitting an error on the connection
+  if (seqid) {
+    callback = this.client._reqs[seqid];
+
+    // Ensure callback can only fire once
+    // TODO this really isn't the right place to set this
+    // Consider moving it to a wrapper around the thrift
+    // client library
+    if (!(callback instanceof thrift.CallOnce)) {
+      callback = thrift.CallOnce(callback);
+      this.client._reqs[seqid] = callback;
+    }
+  }
+
   // TODO if we are framing or multiplexing then we probably
   // want to do Multipart here. See also pooling
   self.nodeOptions.headers["Content-length"] = data.length;
@@ -265,14 +311,19 @@ HttpConnection.prototype.write = function(data) {
   // keep-alive
   // TODO improve http pooling with something like lb_pool
   var req = (self.https) ?
-      https.request(self.nodeOptions, self.responseCallback) :
-      http.request(self.nodeOptions, self.responseCallback);
-  // TODO return HTTP errors back to the callback site
-  // This will require getting access to the callback
-  // Either via having the seqid or the callback itself
-  req.on('error', function(err) {
-    self.emit("error", err);
-  });  
+      https.request(self.nodeOptions, self.responseCallback.bind(null, seqid)) :
+      http.request(self.nodeOptions, self.responseCallback.bind(null, seqid));
+
+  // return HTTP errors back to the callback site
+  // if we got the seqid
+  if (callback) {
+    req.on('error', callback);
+  } else {
+    req.on('error', function(err) {
+      self.emit("error", err);
+    });
+  }
+
   req.write(data);
   req.end();
 };
@@ -297,10 +348,10 @@ exports.createHttpConnection = function(host, port, options) {
  * @returns {object} The client object.
  * @see {@link createHttpConnection}
  */
-exports.createHttpClient = function(cls, httpConnection) {
+exports.createHttpClient = function(ServiceClient, httpConn) {
   // TODO validate required options and throw otherwise
-  if (cls.Client) {
-    cls = cls.Client;
+  if (ServiceClient.Client) {
+    ServiceClient = ServiceClient.Client;
   }
   // TODO detangle these initialization calls
   // creating http "client" requires
@@ -313,9 +364,15 @@ exports.createHttpClient = function(cls, httpConnection) {
   // New transport instance requires
   //   - Buffer to use (or none)
   //   - Callback to call on flush
-  httpConnection.client = 
-    new cls(new httpConnection.transport(undefined, function(buf) {httpConnection.write(buf);}), 
-            httpConnection.protocol);
-  return httpConnection.client;
+
+  // Wrap the wreite method
+  var writeCb = function(buf, seqid) {
+    httpConn.write(buf,seqid);
+  };
+  var transport = new httpConn.transport(undefined, writeCb);
+  var client = new ServiceClient(transport, httpConn.protocol);
+  transport.client = client;
+  httpConn.client = client;
+  return httpConn.client;
 };
 

--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -24,6 +24,9 @@ var thrift = require('./thrift');
 var ttransport = require('./transport');
 var tprotocol = require('./protocol');
 
+// TODO add a logger that is off by default
+// should support info/error/debug/etc interface
+
 /**
  * @class
  * @name ConnectOptions
@@ -81,6 +84,9 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
   this.protocol = this.options.protocol || tprotocol.TBinaryProtocol;
 
   //Prepare Node.js options
+  // TODO consider where to put these defaults instead of
+  // of a magic configuration object
+  // TODO not sure why we put these in both self config and nodeOptions
   this.nodeOptions = {
     host: this.host,
     port: this.port || 80,
@@ -102,10 +108,21 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
   //  calling client in multiplexed scenarios
   this.seqId2Service = {};
 
+  // gets singleton transport that has data in its buffers
+  // flush causes this to decode as much is on the transport
+  // as is possible
   function decodeCallback(transport_with_data) {
+    // create (another) new protocol for the transport
+    // not sure why this is needed since each call to the
+    // service client also does `new this.pClass(this.output)`
+    // in the send_ method seems like duplication
     var proto = new self.protocol(transport_with_data);
+    // TODO hopefully scrap this with better loop flow control
     try {
+      // TODO better loop flow control
+      // I just can not get behind using exceptions to break this loop
       while (true) {
+        // TODO check if this throws
         var header = proto.readMessageBegin();
         var dummy_seqid = header.rseqid * -1;
         var client = self.client;
@@ -121,11 +138,20 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
         //  should bring this stuff inline with typical thrift I/O stack 
         //  operation soon.
         //  --ra
+        // I am pretty sure that this does not get called in most cases
+        // Since unless you are using multiplex_protocol nothing sets values
+        // in to the seqId2Service map --Tom
         var service_name = self.seqId2Service[header.rseqid];
         if (service_name) {
           client = self.client[service_name];
           delete self.seqId2Service[header.rseqid];
         }
+        // This replaces the called back of the real seqid in the client's
+        // stack with a callback on its negative compliment
+        // when called it commits the read head on the transport
+        // removes the real seqid and calls the callback if any
+        // relies on a slightly gross closure reference to 
+        // header.rseqid to know what the callback should be --Tom
         /*jshint -W083 */
         client._reqs[dummy_seqid] = function(err, success){ 
           transport_with_data.commitPosition();
@@ -136,10 +162,20 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
           }
         };
         /*jshint +W083 */
+        // Call recv_ function in client if it can be found
         if(client['recv_' + header.fname]) {
           client['recv_' + header.fname](proto, header.mtype, dummy_seqid);
         } else {
           delete client._reqs[dummy_seqid];
+          // TODO decide if this is correctly emitting or should be associated
+          // with a calbback site.
+          // This might be the only correct use of self.emit('error')
+          // I think this should only happen in the case of multiplexing
+          // or something else very weird
+          // That said a given http request should be tied to a single
+          // callback so we should be able to associate it anyway
+          // until we have actual multiplexing
+          // This might be something that could be caused by a server error --Tom
           self.emit("error",
                     new thrift.TApplicationException(
                        thrift.TApplicationExceptionType.WRONG_METHOD_NAME,
@@ -149,8 +185,16 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
     }
     catch (e) {
       if (e instanceof ttransport.InputBufferUnderrunError) {
+        // TODO Unclear if this is an error or an expected
+        // case in TFramed. We should add logging if it is an error
+        // Also unclear what the recovery is from rollback to 0
         transport_with_data.rollbackPosition();
       } else {
+        // TODO do not throw in callbacks
+        // this should return an error to the callback
+        // or if it happens after it should be logged and
+        // noop.
+        // TODO logging here
         throw e;
       }
     }
@@ -159,10 +203,18 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
       
   //Response handler
   //////////////////////////////////////////////////
+  // this obviously breaks streaming
+  // probably we do not care about that
+  // but maybe we do
+  // TODO replace with a stream safe buffering implementation
   this.responseCallback = function(response) {
     var data = [];
     var dataLen = 0;
 
+    // TODO callback the error instead of just vomitting
+    // all errors at the singleton client
+    // this will requiring have access to the callback 
+    // or at least its seqid
     response.on('error', function (e) {
       self.emit("error", e);
     });
@@ -189,6 +241,8 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
       }
       //Get the receiver function for the transport and
       //  call it with the buffer
+      //  TODO ensure that reciever can not throw
+      //  or if it does catch and callback those errors
       self.transport.receiver(decodeCallback)(buf);
     });
   };
@@ -204,10 +258,18 @@ util.inherits(HttpConnection, EventEmitter);
  */
 HttpConnection.prototype.write = function(data) {
   var self = this;
+  // TODO if we are framing or multiplexing then we probably
+  // want to do Multipart here. See also pooling
   self.nodeOptions.headers["Content-length"] = data.length;
+  // The node global pooling is ok for now but does not support
+  // keep-alive
+  // TODO improve http pooling with something like lb_pool
   var req = (self.https) ?
       https.request(self.nodeOptions, self.responseCallback) :
       http.request(self.nodeOptions, self.responseCallback);
+  // TODO return HTTP errors back to the callback site
+  // This will require getting access to the callback
+  // Either via having the seqid or the callback itself
   req.on('error', function(err) {
     self.emit("error", err);
   });  
@@ -236,9 +298,21 @@ exports.createHttpConnection = function(host, port, options) {
  * @see {@link createHttpConnection}
  */
 exports.createHttpClient = function(cls, httpConnection) {
+  // TODO validate required options and throw otherwise
   if (cls.Client) {
     cls = cls.Client;
   }
+  // TODO detangle these initialization calls
+  // creating http "client" requires
+  //   - new service client instance
+  //
+  // New service client instance requires
+  //   - new transport instance
+  //   - protocol class reference
+  //
+  // New transport instance requires
+  //   - Buffer to use (or none)
+  //   - Callback to call on flush
   httpConnection.client = 
     new cls(new httpConnection.transport(undefined, function(buf) {httpConnection.write(buf);}), 
             httpConnection.protocol);

--- a/lib/nodejs/lib/thrift/protocol.js
+++ b/lib/nodejs/lib/thrift/protocol.js
@@ -25,6 +25,15 @@ var binary = require('./binary'),
 
 var InputBufferUnderrunError = require('./transport').InputBufferUnderrunError;
 
+var log = {
+  'info' : function logInfo() {},
+  'warning' : function logWarning() {},
+  'error' : function logError() {},
+  'debug' : function logDebug() {},
+  'trace' : function logTrace() {}
+};
+
+
 //
 // BINARY PROTOCOL
 //
@@ -58,9 +67,22 @@ TBinaryProtocol.prototype.writeMessageBegin = function(name, type, seqid) {
       this.writeByte(type);
       this.writeI32(seqid);
     }
+    // Record client seqid to find callback again
+    if (this._seqid) {
+      // TODO better logging log warning
+      log.warning('SeqId already set', { 'name': name });
+    } else {
+      this._seqid = seqid;
+      this.trans.setCurrSeqId(seqid);
+    }
 };
 
 TBinaryProtocol.prototype.writeMessageEnd = function() {
+    if (this._seqid) {
+        this._seqid = null;
+    } else {
+        log.warning('No seqid to unset');
+    }
 };
 
 TBinaryProtocol.prototype.writeStructBegin = function(name) {

--- a/lib/nodejs/lib/thrift/thrift.js
+++ b/lib/nodejs/lib/thrift/thrift.js
@@ -155,6 +155,7 @@ var CallOnce = exports.CallOnce = function CallOnce(cb) {
     return function CallOnceCb() {
         if (!self.called) {
           // TODO maybe leaking arguments here
+          // TODO process nextTick
           return self.cb.apply(this, arguments);
         }
         //TODO maybe add logging of double calls

--- a/lib/nodejs/lib/thrift/thrift.js
+++ b/lib/nodejs/lib/thrift/thrift.js
@@ -144,6 +144,24 @@ var TProtocolException = exports.TProtocolException = function(type, message) {
 };
 util.inherits(TProtocolException, Error);
 
+
+var CallOnce = exports.CallOnce = function CallOnce(cb) {
+    if(!(this instanceof CallOnce)) return new CallOnce(cb);
+
+    this.called = false;
+    this.cb = cb;
+    var self = this;
+
+    return function CallOnceCb() {
+        // TODO maybe leaking arguments here
+        var args = (arguments.length === 1) ? [arguments[0]] : Array.apply(null, arguments);
+        if (!self.called) {
+          return self.cb.apply(this, args);
+        }
+        //TODO maybe add logging of double calls
+    };
+};
+
 exports.objectLength = function(obj) {
   return Object.keys(obj).length;
 };

--- a/lib/nodejs/lib/thrift/thrift.js
+++ b/lib/nodejs/lib/thrift/thrift.js
@@ -153,10 +153,9 @@ var CallOnce = exports.CallOnce = function CallOnce(cb) {
     var self = this;
 
     return function CallOnceCb() {
-        // TODO maybe leaking arguments here
-        var args = (arguments.length === 1) ? [arguments[0]] : Array.apply(null, arguments);
         if (!self.called) {
-          return self.cb.apply(this, args);
+          // TODO maybe leaking arguments here
+          return self.cb.apply(this, arguments);
         }
         //TODO maybe add logging of double calls
     };

--- a/lib/nodejs/lib/thrift/transport.js
+++ b/lib/nodejs/lib/thrift/transport.js
@@ -33,7 +33,7 @@ var TFramedTransport = exports.TFramedTransport = function(buffer, callback) {
   this.readPos = 0;
   this.onFlush = callback;
 };
-TFramedTransport.receiver = function(callback) {
+TFramedTransport.receiver = function(callback, seqid) {
   var residual = null;
 
   return function(data) {
@@ -60,7 +60,7 @@ TFramedTransport.receiver = function(callback) {
       var frame = data.slice(4, 4 + frameSize);
       residual = data.slice(4 + frameSize);
 
-      callback(new TFramedTransport(frame));
+      callback(new TFramedTransport(frame), seqid);
 
       data = residual;
       residual = null;
@@ -76,6 +76,13 @@ TFramedTransport.prototype = {
   isOpen: function() {return true;},
   open: function() {},
   close: function() {},
+
+
+  // Set the seqid of the message in the client
+  // So that callbacks can be found
+  setCurrSeqId: function(seqid) {
+    this._seqid = seqid;
+  },
 
   ensureAvailable: function(len) {
     if (this.readPos + len > this.inBuf.length) {
@@ -146,6 +153,11 @@ TFramedTransport.prototype = {
   },
 
   flush: function() {
+    // If the seqid of the callback is available pass it to the onFlush
+    // Then remove the current seqid
+    var seqid = this._seqid;
+    this._seqid = null;
+
     var out = new Buffer(this.outCount),
         pos = 0;
     this.outBuffers.forEach(function(buf) {
@@ -158,7 +170,8 @@ TFramedTransport.prototype = {
       var msg = new Buffer(out.length + 4);
       binary.writeI32(msg, out.length);
       out.copy(msg, 4, 0, out.length);
-      this.onFlush(msg);
+      // Passing seqid through this call to get it to the connection
+      this.onFlush(msg, seqid);
     }
 
     this.outBuffers = [];
@@ -176,7 +189,7 @@ var TBufferedTransport = exports.TBufferedTransport = function(buffer, callback)
   this.outCount = 0;
   this.onFlush = callback;
 };
-TBufferedTransport.receiver = function(callback) {
+TBufferedTransport.receiver = function(callback, seqid) {
   var reader = new TBufferedTransport();
 
   return function(data) {
@@ -188,7 +201,7 @@ TBufferedTransport.receiver = function(callback) {
     data.copy(reader.inBuf, reader.writeCursor, 0);
     reader.writeCursor += data.length;
 
-    callback(reader);
+    callback(reader, seqid);
   };
 };
 
@@ -213,6 +226,12 @@ TBufferedTransport.prototype = {
   isOpen: function() {return true;},
   open: function() {},
   close: function() {},
+
+  // Set the seqid of the message in the client
+  // So that callbacks can be found
+  setCurrSeqId: function(seqid) {
+    this._seqid = seqid;
+  },
 
   ensureAvailable: function(len) {
     if (this.readCursor + len > this.writeCursor) {
@@ -279,6 +298,11 @@ TBufferedTransport.prototype = {
   },
 
   flush: function() {
+    // If the seqid of the callback is available pass it to the onFlush
+    // Then remove the current seqid
+    var seqid = this._seqid;
+    this._seqid = null;
+
     if (this.outCount < 1) {
       return;
     }
@@ -290,9 +314,8 @@ TBufferedTransport.prototype = {
       pos += buf.length;
     });
     
-    if (this.onFlush) {
-      this.onFlush(msg);
-    }
+    // Passing seqid through this call to get it to the connection
+    this.onFlush(msg, seqid);
 
     this.outBuffers = [];
     this.outCount = 0;

--- a/lib/nodejs/lib/thrift/transport.js
+++ b/lib/nodejs/lib/thrift/transport.js
@@ -170,8 +170,10 @@ TFramedTransport.prototype = {
       var msg = new Buffer(out.length + 4);
       binary.writeI32(msg, out.length);
       out.copy(msg, 4, 0, out.length);
-      // Passing seqid through this call to get it to the connection
-      this.onFlush(msg, seqid);
+      if (this.onFlush) {
+        // Passing seqid through this call to get it to the connection
+        this.onFlush(msg, seqid);
+      }
     }
 
     this.outBuffers = [];
@@ -314,8 +316,10 @@ TBufferedTransport.prototype = {
       pos += buf.length;
     });
     
-    // Passing seqid through this call to get it to the connection
-    this.onFlush(msg, seqid);
+    if (this.onFlush) {
+      // Passing seqid through this call to get it to the connection
+      this.onFlush(msg, seqid);
+    }
 
     this.outBuffers = [];
     this.outCount = 0;

--- a/lib/nodejs/test/thrift_test_driver.js
+++ b/lib/nodejs/test/thrift_test_driver.js
@@ -52,6 +52,7 @@ function checkRecursively(map1, map2) {
 }
 
 client.testVoid(function(err, response) {
+  console.log(err);
   assert( ! err);
   assert.equal(undefined, response); //void
 });


### PR DESCRIPTION
Injects the seqid to allow the connection to reference the callback and then associates as many request specific errors with the callback as possible.

Also wraps the callback so that it only fires once.

TODOs logging, more unit tests

I need to find an a better unit testing library for Node that is Apache 2.0 compatible (e.g. upstreamable).

cc @Raynos @kriskowal @sectioneight @breerly @willyham @danielheller