### PR TITLE
Wire up TCompact

### DIFF
--- a/lib/nodejs/lib/thrift/protocol.js
+++ b/lib/nodejs/lib/thrift/protocol.js
@@ -597,6 +597,15 @@ TCompactProtocol.prototype.writeMessageBegin = function(name, type, seqid) {
                      ((type << TCompactProtocol.TYPE_SHIFT_AMOUNT) & TCompactProtocol.TYPE_MASK));
   this.writeVarint32(seqid);
   this.writeString(name);
+
+  // Record client seqid to find callback again
+  if (this._seqid) {
+    // TODO better logging log warning
+    log.warning('SeqId already set', { 'name': name });
+  } else {
+    this._seqid = seqid;
+    this.trans.setCurrSeqId(seqid);
+  }
 };
 
 TCompactProtocol.prototype.writeMessageEnd = function() {


### PR DESCRIPTION
TCompact wasn't wired up and I missed it because the Thrift tests focus on Binary.

cc @sectioneight @Willyham @Raynos @kriskowal 