### PR TITLE
Add test coverage for Node.js

### DIFF
--- a/lib/nodejs/.gitignore
+++ b/lib/nodejs/.gitignore
@@ -1,0 +1,1 @@
+coverage

--- a/lib/nodejs/package.json
+++ b/lib/nodejs/package.json
@@ -31,15 +31,18 @@
   },
   "dependencies": {
     "node-int64": "~0.3.0",
-    "q": "1.0.x",
     "nodeunit": "~0.8.0",
+    "q": "1.0.x",
     "ws": "~0.4.32"
   },
   "devDependencies": {
     "connect": "2.7.x",
-    "commander": "2.1.x"
+    "commander": "2.1.x",
+    "istanbul": "^0.3.5",
+    "tape": "^3.4.0"
   },
   "scripts": {
+    "cover": "test/testAll.sh COVER",
     "test": "test/testAll.sh"
   }
 }

--- a/lib/nodejs/test/testAll.sh
+++ b/lib/nodejs/test/testAll.sh
@@ -177,8 +177,8 @@ testWSClientServer binary framed --ssl || TESTOK=1
 
 if [ -n "${COVER}" ]; then
   ${DIR}/../node_modules/.bin/istanbul report --include "${DIR}/../coverage/report*/coverage.json" lcov cobertura
-  #rm -r ${DIR}/../coverage/report*/*
-  #rmdir ${DIR}/../coverage/report*
+  rm -r ${DIR}/../coverage/report*/*
+  rmdir ${DIR}/../coverage/report*
 fi
 
 exit $TESTOK

--- a/lib/nodejs/test/testAll.sh
+++ b/lib/nodejs/test/testAll.sh
@@ -19,7 +19,13 @@
 # under the License.
 #
 
+if [ -n "${1}" ]; then
+  COVER=${1};
+fi
+
 DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+COUNT=0
 
 export NODE_PATH="${DIR}:${DIR}/../lib:${NODE_PATH}"
 
@@ -27,11 +33,21 @@ testClientServer()
 {
   echo "   Testing Client/Server with protocol $1 and transport $2 $3";
   RET=0
-  node ${DIR}/server.js -p $1 -t $2 $3 &
+  if [ -n "${COVER}" ]; then
+    ${DIR}/../node_modules/.bin/istanbul cover ${DIR}/server.js --dir ${DIR}/../coverage/report${COUNT} --handle-sigint -- -p $1 -t $2 $3 &
+    ((COUNT++))
+  else
+    node ${DIR}/server.js -p $1 -t $2 $3 &
+  fi
   SERVERPID=$!
   sleep 1
-  node ${DIR}/client.js -p $1 -t $2 $3 || RET=1
-  kill -9 $SERVERPID || RET=1
+  if [ -n "${COVER}" ]; then
+    ${DIR}/../node_modules/.bin/istanbul cover ${DIR}/client.js --dir ${DIR}/../coverage/report${COUNT} -- -p $1 -t $2 $3 || RET=1
+    ((COUNT++))
+  else
+    node ${DIR}/client.js -p $1 -t $2 $3 || RET=1
+  fi
+  kill -2 $SERVERPID || RET=1
   return $RET
 }
 
@@ -39,11 +55,21 @@ testMultiplexedClientServer()
 {
   echo "   Testing Multiplexed Client/Server with protocol $1 and transport $2 $3";
   RET=0
-  node ${DIR}/multiplex_server.js -p $1 -t $2 $3 &
+  if [ -n "${COVER}" ]; then
+    ${DIR}/../node_modules/.bin/istanbul cover ${DIR}/multiplex_server.js --dir ${DIR}/../coverage/report${COUNT} --handle-sigint -- -p $1 -t $2 $3 &
+    ((COUNT++))
+  else
+    node ${DIR}/multiplex_server.js -p $1 -t $2 $3 &
+  fi
   SERVERPID=$!
   sleep 1
-  node ${DIR}/multiplex_client.js -p $1 -t $2 $3 || RET=1
-  kill -9 $SERVERPID || RET=1
+  if [ -n "${COVER}" ]; then
+    ${DIR}/../node_modules/.bin/istanbul cover ${DIR}/multiplex_client.js --dir ${DIR}/../coverage/report${COUNT} -- -p $1 -t $2 $3 || RET=1
+    ((COUNT++))
+  else
+    node ${DIR}/multiplex_client.js -p $1 -t $2 $3 || RET=1
+  fi
+  kill -2 $SERVERPID || RET=1
   return $RET
 }
 
@@ -51,11 +77,23 @@ testHttpClientServer()
 {
   echo "   Testing HTTP Client/Server with protocol $1 and transport $2 $3";
   RET=0
-  node ${DIR}/http_server.js -p $1 -t $2 $3 &
+  if [ -n "${COVER}" ]; then
+    ${DIR}/../node_modules/.bin/istanbul cover ${DIR}/http_server.js --dir ${DIR}/../coverage/report${COUNT} --handle-sigint -- -p $1 -t $2 $3 &
+    ((COUNT++))
+  else
+    node ${DIR}/http_server.js -p $1 -t $2 $3 &
+  fi
   SERVERPID=$!
   sleep 1
-  node ${DIR}/http_client.js -p $1 -t $2 $3 || RET=1
-  kill -9 $SERVERPID || RET=1
+  if [ -n "${COVER}" ]; then
+    ${DIR}/../node_modules/.bin/istanbul cover ${DIR}/http_client.js --dir ${DIR}/../coverage/report${COUNT} -- -p $1 -t $2 $3 || RET=1
+    ((COUNT++))
+  else
+    node ${DIR}/http_client.js -p $1 -t $2 $3 || RET=1
+  fi
+
+  kill -2 $SERVERPID || RET=1
+  sleep 1
   return $RET
 }
 
@@ -63,12 +101,23 @@ testWSClientServer()
 {
   echo "   Testing WebSocket Client/Server with protocol $1 and transport $2 $3";
   RET=0
-  node ${DIR}/http_server.js -p $1 -t $2 $3 &
+  if [ -n "${COVER}" ]; then
+    ${DIR}/../node_modules/.bin/istanbul cover ${DIR}/http_server.js --dir ${DIR}/../coverage/report${COUNT} --handle-sigint -- -p $1 -t $2 $3 &
+    ((COUNT++))
+  else
+    node ${DIR}/http_server.js -p $1 -t $2 $3 &
+  fi
   SERVERPID=$!
   sleep 1
-  node ${DIR}/ws_client.js -p $1 -t $2 $3 || RET=1
-  kill -9 $SERVERPID || RET=1
-  return $RET
+  if [ -n "${COVER}" ]; then
+    ${DIR}/../node_modules/.bin/istanbul cover ${DIR}/ws_client.js --dir ${DIR}/../coverage/report${COUNT} -- -p $1 -t $2 $3 || RET=1
+    ((COUNT++))
+  else
+    node ${DIR}/ws_client.js -p $1 -t $2 $3 || RET=1
+  fi
+
+  kill -2 $SERVERPID || RET=1
+  sleep 1
 }
 
 
@@ -125,5 +174,11 @@ testWSClientServer binary buffered || TESTOK=1
 testWSClientServer binary framed || TESTOK=1
 testWSClientServer json buffered --promise || TESTOK=1
 testWSClientServer binary framed --ssl || TESTOK=1
+
+if [ -n "${COVER}" ]; then
+  ${DIR}/../node_modules/.bin/istanbul report --include "${DIR}/../coverage/report*/coverage.json" lcov cobertura
+  #rm -r ${DIR}/../coverage/report*/*
+  #rmdir ${DIR}/../coverage/report*
+fi
 
 exit $TESTOK


### PR DESCRIPTION
cc @sectioneight @breerly @Raynos @kriskowal @Willyham 

I'd like to move to Tape but I wanted to get the coverage before I rewrote all the tests.
I'd also like to add testing server/client pairs from Python, Java, Go and any other languages we use somewhere maybe that doesn't belong in the Node branch though.