### PR TITLE
Fix bad references to TProtocolException and TProtocolExceptionType

### DIFF
--- a/lib/nodejs/lib/thrift/protocol.js
+++ b/lib/nodejs/lib/thrift/protocol.js
@@ -756,7 +756,7 @@ TCompactProtocol.prototype.writeVarint64 = function(n) {
     n = new Int64(n);
   }
   if (! (n instanceof Int64)) {
-    throw new TProtocolException(INVALID_DATA, "Expected Int64 or Number, found: " + n);
+    throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.INVALID_DATA, "Expected Int64 or Number, found: " + n);
   }
   
   var buf = new Buffer(10);
@@ -819,14 +819,14 @@ TCompactProtocol.prototype.readMessageBegin = function() {
   //Read protocol ID
   var protocolId = this.trans.readByte();
   if (protocolId != TCompactProtocol.PROTOCOL_ID) {
-    throw new TProtocolException(BAD_VERSION, "Bad protocol identifier " + protocolId);
+    throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.BAD_VERSION, "Bad protocol identifier " + protocolId);
   }
 
   //Read Version and Type
   var versionAndType = this.trans.readByte();
   var version = (versionAndType & TCompactProtocol.VERSION_MASK);
   if (version != TCompactProtocol.VERSION_N) {
-    throw new TProtocolException(BAD_VERSION, "Bad protocol version " + version);
+    throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.BAD_VERSION, "Bad protocol version " + version);
   }
   var type = ((versionAndType >> TCompactProtocol.TYPE_SHIFT_AMOUNT) & TCompactProtocol.TYPE_BITS);
 

--- a/lib/nodejs/lib/thrift/protocol.js
+++ b/lib/nodejs/lib/thrift/protocol.js
@@ -534,7 +534,7 @@ TCompactProtocol.prototype.getTType = function(type) {
     case TCompactProtocol.Types.CT_STRUCT:
       return Type.STRUCT;
     default:
-      throw new Thrift.TProtocolException(Thift.TProtocolExceptionType.INVALID_DATA, "Unknown type: " + type);
+      throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.INVALID_DATA, "Unknown type: " + type);
   }
   return Type.STOP;
 };


### PR DESCRIPTION
TCompact had some bad code on 0.9.2 and master. This fixes that we don't throw exception in our exceptions.

cc @malandrew @kriskowal @Raynos @Willyham 