### PR TITLE
Add socket timeout support

### DIFF
--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -272,6 +272,14 @@ var HttpConnection = exports.HttpConnection = function(host, port, options) {
 util.inherits(HttpConnection, EventEmitter);
 
 /**
+ * Set the socket timeout value in ms.
+ * @param {Number} timeout The socket timeout
+ */
+HttpConnection.prototype.setSocketTimeout = function(timeout){
+  this.nodeOptions.socketTimeout = timeout;
+};
+
+/**
  * Writes Thrift message data to the connection
  * @param {Buffer} data - A Node.js Buffer containing the data to write
  * @returns {void} No return value.
@@ -308,7 +316,7 @@ HttpConnection.prototype.write = function(data, seqid) {
 
   var timeout = self.nodeOptions.socketTimeout;
   if (typeof timeout === 'number' && !isNaN(timeout)) {
-    req.setTimeout(self.nodeOptions.socketTimeout, function() {
+    req.setTimeout(timeout, function() {
       req.emit('error', new Error('Socket timeout'));
     });
   }

--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -306,6 +306,13 @@ HttpConnection.prototype.write = function(data, seqid) {
       https.request(self.nodeOptions, self.responseCallback.bind(null, seqid)) :
       http.request(self.nodeOptions, self.responseCallback.bind(null, seqid));
 
+  var timeout = self.nodeOptions.socketTimeout;
+  if (typeof timeout === 'number' && !isNaN(timeout)) {
+    req.setTimeout(self.nodeOptions.socketTimeout, function() {
+      req.emit('error', new Error('Socket timeout'));
+    });
+  }
+
   // return HTTP errors back to the callback site
   // if we got the seqid
   if (callback) {

--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -275,7 +275,7 @@ util.inherits(HttpConnection, EventEmitter);
  * Set the socket timeout value in ms.
  * @param {Number} timeout The socket timeout
  */
-HttpConnection.prototype.setSocketTimeout = function(timeout){
+HttpConnection.prototype.setSocketTimeout = function setSocketTimeout(timeout){
   this.nodeOptions.socketTimeout = timeout;
 };
 

--- a/lib/nodejs/lib/thrift/http_connection.js
+++ b/lib/nodejs/lib/thrift/http_connection.js
@@ -317,7 +317,9 @@ HttpConnection.prototype.write = function(data, seqid) {
   var timeout = self.nodeOptions.socketTimeout;
   if (typeof timeout === 'number' && !isNaN(timeout)) {
     req.setTimeout(timeout, function() {
-      req.emit('error', new Error('Socket timeout'));
+      var error = new Error('ETIMEDOUT');
+      error.code = 'ETIMEDOUT';
+      req.emit('error', error);
     });
   }
 


### PR DESCRIPTION
@sh1mmer @breerly @kriskowal @Raynos 

Add the ability to set a socketTimeout option which will be added to every request if set. We also need to be able to set the timeout on the instance of an HttpConnection so that we can dynamically change the timeout for requests (e.g. by changing a flipr property).

I am not very familiar with the internals of node networking, so please take a good look at this.