### PR TITLE
[py] [BinaryAccel] Always expect unicode strings.

### DIFF
--- a/lib/py/src/protocol/fastbinary.c
+++ b/lib/py/src/protocol/fastbinary.c
@@ -414,6 +414,14 @@ output_val(PyObject* output, PyObject* value, TType type, PyObject* typeargs) {
   }
 
   case T_STRING: {
+    bool is_unicode = PyUnicode_CheckExact(value);
+    if (is_unicode) {
+        value = PyUnicode_AsUTF8String(value);
+        if (value == NULL) {
+            PyErr_SetString(PyExc_TypeError, "can not encode using utf8");
+            return false;
+        }
+    }
     Py_ssize_t len = PyString_Size(value);
 
     if (!check_ssize_t_32(len)) {
@@ -422,6 +430,10 @@ output_val(PyObject* output, PyObject* value, TType type, PyObject* typeargs) {
 
     writeI32(output, (int32_t) len);
     PycStringIO->cwrite(output, PyString_AsString(value), (int32_t) len);
+
+    if (is_unicode) {
+        Py_DECREF(value);
+    }
     break;
   }
 
@@ -1009,7 +1021,7 @@ decode_val(DecodeBuffer* input, TType type, PyObject* typeargs) {
       return NULL;
     }
 
-    return PyString_FromStringAndSize(buf, len);
+    return PyUnicode_FromStringAndSize(buf, len);
   }
 
   case T_LIST:


### PR DESCRIPTION
`fastbinary` currently ignores the `utf8strings` flag. That is undesirable
because when `utf8strings` is set, `TBinaryProtocolAccelerated` will just
start failing serialization attempts of unicode strings.

This changes it to always expect UTF-8 strings.

This is a quick short-term fix. A more complete fix is to change the compiler
to pass whether `utf8strings` is set to the library and transform strings
accordingly. See fbthrift's fastbinary.c.