### PR TITLE
Expose clear_write_buffer in TBufferedTransport

### DIFF
--- a/lib/py/setup.py
+++ b/lib/py/setup.py
@@ -71,7 +71,7 @@ def run_setup(with_binary):
         extensions = dict()
         
     setup(name = 'thrift',
-        version = '0.9.2-uber1',
+        version = '0.9.2-uber2',
         description = 'Python bindings for the Apache Thrift RPC system',
         author = 'Thrift Developers',
         author_email = 'dev@thrift.apache.org',

--- a/lib/py/src/transport/TTransport.py
+++ b/lib/py/src/transport/TTransport.py
@@ -162,6 +162,9 @@ class TBufferedTransport(TTransportBase, CReadableTransport):
   def write(self, buf):
     self.__wbuf.write(buf)
 
+  def clear_write_buffer(self):
+    self.__wbuf = StringIO()
+
   def flush(self):
     out = self.__wbuf.getvalue()
     # reset wbuf before write/flush to preserve state on underlying failure


### PR DESCRIPTION
We need this to be able to handle failures during write correctly.

Right now, the buffer is left in a stale state if the attempt to write to the buffer fails because of invalid data types.