### PR TITLE
fastbinary `utf8strings` support

### DIFF
--- a/lib/py/src/protocol/fastbinary.c
+++ b/lib/py/src/protocol/fastbinary.c
@@ -414,14 +414,6 @@ output_val(PyObject* output, PyObject* value, TType type, PyObject* typeargs) {
   }
 
   case T_STRING: {
-    bool is_unicode = PyUnicode_CheckExact(value);
-    if (is_unicode) {
-        value = PyUnicode_AsUTF8String(value);
-        if (value == NULL) {
-            PyErr_SetString(PyExc_TypeError, "can not encode using utf8");
-            return false;
-        }
-    }
     Py_ssize_t len = PyString_Size(value);
 
     if (!check_ssize_t_32(len)) {
@@ -430,10 +422,6 @@ output_val(PyObject* output, PyObject* value, TType type, PyObject* typeargs) {
 
     writeI32(output, (int32_t) len);
     PycStringIO->cwrite(output, PyString_AsString(value), (int32_t) len);
-
-    if (is_unicode) {
-        Py_DECREF(value);
-    }
     break;
   }
 
@@ -1021,7 +1009,7 @@ decode_val(DecodeBuffer* input, TType type, PyObject* typeargs) {
       return NULL;
     }
 
-    return PyUnicode_FromStringAndSize(buf, len);
+    return PyString_FromStringAndSize(buf, len);
   }
 
   case T_LIST:


### PR DESCRIPTION
`fastbinary` does not currently respect the `utf8strings` flag.
Relevant JIRA ticket: https://issues.apache.org/jira/browse/THRIFT-1229

This is an as yet unmerged patch submitted to the original JIRA ticket by
James Haggerty. It changes the Python code generator to include whether a type
is unicode or not in the `thrift_spec`, and `fastbinary` to use that
information to UTF-8 encode/decode values.

This change is *not compatible with Python 3*. The behavior will have to be
altered slightly to account for the changes in `str`/`bytes`/`unicode` in
Python 3.
